### PR TITLE
Fixed misleading indentation

### DIFF
--- a/source/Lib/TLibCommon/TComPicYuv.cpp
+++ b/source/Lib/TLibCommon/TComPicYuv.cpp
@@ -148,8 +148,16 @@ Void TComPicYuv::destroy()
 
   for(UInt chan=0; chan<MAX_NUM_CHANNEL_TYPE; chan++)
   {
-    if (m_cuOffset[chan]) delete[] m_cuOffset[chan]; m_cuOffset[chan] = NULL;
-    if (m_buOffset[chan]) delete[] m_buOffset[chan]; m_buOffset[chan] = NULL;
+    if (m_cuOffset[chan])
+    {
+      delete[] m_cuOffset[chan];
+      m_cuOffset[chan] = NULL;
+    }
+    if (m_buOffset[chan])
+    {
+      delete[] m_buOffset[chan];
+      m_buOffset[chan] = NULL;
+    }
   }
 }
 


### PR DESCRIPTION
Compilation with GCC version 10.2.1 failed

make[1]: Entering directory '/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon'
g++ -c -MMD -MF ./objects/Debug.d.d -MT ./objects/Debug.d.o -fPIC -DMSYS_LINUX -I/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib -I../../../../source/Lib/TLibCommon -Wall -Wshadow -Wno-sign-compare -Werror -g  -D_DEBUG -o objects/Debug.d.o /1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib/TLibCommon/Debug.cpp
g++ -c -MMD -MF ./objects/TComPicYuv.d.d -MT ./objects/TComPicYuv.d.o -fPIC -DMSYS_LINUX -I/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib -I../../../../source/Lib/TLibCommon -Wall -Wshadow -Wno-sign-compare -Werror -g  -D_DEBUG -o objects/TComPicYuv.d.o /1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib/TLibCommon/TComPicYuv.cpp
/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib/TLibCommon/TComPicYuv.cpp: In member function ‘Void TComPicYuv::destroy()’:
/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib/TLibCommon/TComPicYuv.cpp:151:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
  151 |     if (m_cuOffset[chan]) delete[] m_cuOffset[chan]; m_cuOffset[chan] = NULL;
      |     ^~
/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib/TLibCommon/TComPicYuv.cpp:151:54: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  151 |     if (m_cuOffset[chan]) delete[] m_cuOffset[chan]; m_cuOffset[chan] = NULL;
      |                                                      ^~~~~~~~~~
make[1]: Leaving directory '/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon'
/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib/TLibCommon/TComPicYuv.cpp:152:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
  152 |     if (m_buOffset[chan]) delete[] m_buOffset[chan]; m_buOffset[chan] = NULL;
      |     ^~
/1TB/usr/src/github.com/1div0/libHM/build/linux/lib/TLibCommon/../../../../source/Lib/TLibCommon/TComPicYuv.cpp:152:54: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  152 |     if (m_buOffset[chan]) delete[] m_buOffset[chan]; m_buOffset[chan] = NULL;
      |                                                      ^~~~~~~~~~
cc1plus: all warnings being treated as errors
make[1]: *** [../../common/makefile.base:263: objects/TComPicYuv.d.o] Error 1